### PR TITLE
Persist MealPlanGenerator food favorites via useFavorites hook

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -283,7 +283,6 @@ function AuthenticatedApp() {
     }
   }
 
-  const isFoodItemFavorite = (id: string) => isFavorite(id)
   const isItemInListByName = (name: string) => shoppingListItems.some((i: { name: string }) => i.name === name)
 
   // Effect to sync AI hook error to local state if needed


### PR DESCRIPTION
### Motivation
- Enable the meal planner to persist food-item favorites using the existing favorites persistence API instead of a placeholder notification.

### Description
- Destructured `toggleFoodItemFavorite` and `isFoodItemFavorite` from `useFavorites` and replaced the `MealPlanGenerator` `onToggleFavorite` placeholder with `onToggleFavorite={(item) => toggleFoodItemFavorite({ id: item.id, name: item.name, calories: item.calories, protein: item.protein, carbs: item.carbs, fat: item.fat, emoji: item.emoji })}` while keeping the `notifyInfo` call; also updated `isFavorite` to use `isFoodItemFavorite(item.id)`.

### Testing
- Ran `npm run typecheck` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e13aaaa8483259883f55d2e078479)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved favorites system with better integration for food items, now tracking additional meal details when items are marked as favorites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->